### PR TITLE
Don't map the default prefix if 'EasyMotion_do_mapping' is explicitly unset

### DIFF
--- a/src/main/kotlin/org/jetbrains/plugins/extension/easymotion/EasyMotionExtension.kt
+++ b/src/main/kotlin/org/jetbrains/plugins/extension/easymotion/EasyMotionExtension.kt
@@ -73,7 +73,9 @@ class EasyMotionExtension : VimExtension {
     }
 
     override fun init() {
-        VimScriptGlobalEnvironment.getInstance().variables.let { vars ->
+        val vimScriptVariables = VimScriptGlobalEnvironment.getInstance().variables
+
+        vimScriptVariables.let { vars ->
             vars[jumpAnywhere] = defaultRe
             vars[lineJumpAnywhere] = defaultRe
             if (doMapping !in vars) vars[doMapping] = 1
@@ -187,10 +189,11 @@ class EasyMotionExtension : VimExtension {
         )
 
         // @formatter:on
+        if (vimScriptVariables[doMapping] == 1) {
+            putKeyMapping(MappingMode.NVO, parseKeys(defaultPrefix), owner, parseKeys(pluginPrefix), true)
+        }
 
-        putKeyMapping(MappingMode.NVO, parseKeys(defaultPrefix), owner, parseKeys(pluginPrefix), true)
-
-        if (VimScriptGlobalEnvironment.getInstance().variables[overrideAcejump] == 1) {
+        if (vimScriptVariables[overrideAcejump] == 1) {
             MappingConfigurator.configureMappings()
         }
     }


### PR DESCRIPTION
In cases where `<leader><leader>` is used in other mappings, it's useful to have `g:EasyMotion_do_mapping` disable it from being mapped by the plugin